### PR TITLE
permit https hosted schema paths

### DIFF
--- a/internal/impl/avro/processor.go
+++ b/internal/impl/avro/processor.go
@@ -205,8 +205,8 @@ func newAvroFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (serv
 		return nil, err
 	}
 	if schemaPath != "" {
-		if !(strings.HasPrefix(schemaPath, "file://") || strings.HasPrefix(schemaPath, "http://")) {
-			return nil, errors.New("invalid schema_path provided, must start with file:// or http://")
+		if !(strings.HasPrefix(schemaPath, "file://") || strings.HasPrefix(schemaPath, "http://") || strings.HasPrefix(schemaPath, "https://")) {
+			return nil, errors.New("invalid schema_path provided, must start with file://, http:// or https://")
 		}
 		if schema, err = loadSchema(schemaPath); err != nil {
 			return nil, fmt.Errorf("failed to load Avro schema definition: %v", err)


### PR DESCRIPTION
### Description

This pull request updates the validation logic for `schemaPath` to allow URLs that start with `https://` in addition to `file://` and `http://`.

### Changes

- Modified the condition in the `schemaPath` validation to include a check for the `https://` prefix.
- Updated the error message to reflect the new allowed prefix `https://`.

### Reason

Previously, the `schemaPath` validation only allowed URLs starting with `file://` or `http://`. This update allows for more secure connections by accepting CDN or GitHub raw hosted schemas.
